### PR TITLE
Redefine groups as sets over lists

### DIFF
--- a/balanced_group_system/__init__.py
+++ b/balanced_group_system/__init__.py
@@ -1,2 +1,3 @@
 from .group_system import GroupSystem
 from .balanced_group_system import BalancedGroupSystem
+from .available_group_scheduler import AvailableGroupScheduler

--- a/balanced_group_system/available_group_scheduler.py
+++ b/balanced_group_system/available_group_scheduler.py
@@ -1,0 +1,88 @@
+import random
+from . import group_system
+
+"""
+AvailableGroupScheduler.py
+
+This module contains a subclass of GroupScheduler that creates groups based on the
+familiarity matrix and takes into account member availability. It creates groups
+in such a way that members meet as many new members as possible and minimize
+repeat meetings.
+
+Author: Joshua Si
+"""
+
+class AvailableGroupScheduler(group_system.GroupSystem):
+  def __init__(self, members: list[str] = [], availability_schedules: list[list[bool]] = []):
+    super().__init__(members)
+    self.familiarity_matrix: dict[frozenset[tuple[str, str]], int] = {frozenset((self.members[i], self.members[j])) : 0 for i in range(len(self.members)) for j in range(i+1, len(self.members))}
+    self.participation_count: dict[int] = {member: 0 for member in self.members}
+    if len(availability_schedules) == 0:
+      self.availability_schedules: list[list[bool]] = [[True for _ in range(len(members))]]
+    else:
+      self.availability_schedules: list[list[bool]] = availability_schedules
+
+  def add_schedule(self, availability: list[bool]) -> None:
+    self.availability_schedules.append(availability)
+
+  def update_participation(self, group: set[str]) -> None:
+    for member in group:
+      self.participation_count[member] += 1
+      for m in group:
+        if member != m:
+          self.familiarity_matrix[frozenset((member, m))] += 1
+
+  def create_balanced_schedules(self, group_size: int) -> list[set[str]]:
+    self.familiarity_matrix: dict[frozenset[tuple[str, str]], int] = {frozenset((self.members[i], self.members[j])) : 0 for i in range(len(self.members)) for j in range(i+1, len(self.members))}
+    self.participation_count: dict[int] = {member: 0 for member in self.members}
+    schedules = []
+    for availability in range(len(self.availability_schedules)):
+      candidates = set(member for member, avail in zip(self.members, self.availability_schedules[availability]) if avail)
+      # if less candidates than desired group_size, put all possible candidates in the group
+      if len(candidates) < group_size:
+        schedules.append(candidates)
+        continue
+      # otherwise filter for those who have participated the least to maximize new members
+      min_threshold = min(self.participation_count.values())
+      min_participation_candidates = set(member for member in candidates if self.participation_count[member] == min_threshold)
+      if len(min_participation_candidates) > group_size:
+        # now select based on familiarity matrix
+        group = self.get_balanced_group(min_participation_candidates, set(), group_size)
+        schedules.append(group)
+        self.update_participation(group)
+      else:
+        candidates = set(member for member in candidates if member not in min_participation_candidates)
+        min_threshold += 1
+        new_candidates = set(member for member in candidates if self.participation_count[member] == min_threshold)
+        while len(min_participation_candidates) + len(new_candidates) < group_size:
+          new_candidates = set(member for member in candidates if self.participation_count[member] == min_threshold)
+          min_threshold += 1
+          min_participation_candidates = min_participation_candidates | set(member for member in candidates if self.participation_count[member] == min_threshold)
+        group = self.get_balanced_group(new_candidates, min_participation_candidates, group_size)
+        schedules.append(group)
+        self.update_participation(group)
+    return schedules
+
+  # returns group of size group_size, consisting of existing members and adding from candidates based on familiarity
+  def get_balanced_group(self, candidates: set[str], existing: set[str], group_size: int) -> set[str]:
+    group = existing
+    scores = {frozenset(group): 0}
+    # Memoized version of evaluate_group for evaluating score when adding one member
+    def evaluate_member(group: set[str], member: str) -> int:
+      group_key = frozenset(group)
+      new_key = frozenset(group | {member})
+      if new_key in scores:
+        return scores[new_key]
+      score = scores[group_key]
+      for m in group:
+        score += self.familiarity_matrix[frozenset((m, member))]
+      scores[new_key] = score + 1
+      return score + 1
+
+    # Balance and distribute members
+    while len(group) < group_size:
+      min_candidate = min(candidates, key=lambda c: evaluate_member(group, c))
+      group.add(min_candidate)
+      candidates.remove(min_candidate)
+
+    return group

--- a/balanced_group_system/balanced_group_system.py
+++ b/balanced_group_system/balanced_group_system.py
@@ -13,78 +13,83 @@ Author: Joshua Si
 class BalancedGroupSystem(group_system.GroupSystem):
   def __init__(self, members: list[str] = []):
     super().__init__(members)
-    self.familiarity_matrix: list[list[int]] = [[0 for _ in range(len(members))] for _ in range(len(members))]
+    self.familiarity_matrix: dict[frozenset[tuple[str, str]], int] = {
+        frozenset((self.members[i], self.members[j])) : 0
+        for i in range(len(self.members))
+        for j in range(i+1, len(self.members))
+    }
 
   def __repr__(self) -> str:
     return f"BalancedGroupSystem({self.members})"
   
   def add_member(self, member: str) -> None:
     super().add_member(member)
-    for row in self.familiarity_matrix:
-      row.append(0)
-    self.familiarity_matrix.append([0 for _ in range(len(self.members))])
+    for i in range(len(self.members)-1):
+      self.familiarity_matrix[frozenset((self.members[i], member))] = 0
   
   def remove_member(self, member: str) -> None:
     try:
-      index = self.members.index(member)
       super().remove_member(member)
-      for row in self.familiarity_matrix:
-        row.pop(index)
-      self.familiarity_matrix.pop(index)
+      for m in self.members:
+        self.familiarity_matrix.pop(frozenset((m, member)))
     except ValueError:
       raise ValueError("Member '{}' was not in members".format(member))
     
-  def create_groups(self, groups: list[list[str]]) -> list[list[str]]:
+  def create_groups(self, groups: list[set[str]]) -> list[set[str]]:
     super().create_groups(groups)
     for group in groups:
       self.update_familiarity(group)
     return groups
 
   def print_familiarity(self) -> None:
-    print('  ',', '.join(self.members))
-    for i, row in enumerate(self.familiarity_matrix):
-      print(self.members[i], row)
+    for i in self.members:
+      print(i, end=' ')
+    print()
+    for i in self.members:
+      print(i, end=' ')
+      for j in self.members:
+        if i == j:
+          print('-', end=' ')
+        else:
+          print(self.familiarity_matrix[frozenset((i, j))], end=' ')
+      print()
 
-  def evaluate_group(self, group: list[str]) -> int:
+  def evaluate_group(self, group: set[str]) -> int:
     score = 0
-    for i, j in enumerate(group):
-      for k in group[i+1:]:
-        score += self.familiarity_matrix[self.members.index(j)][self.members.index(k)]
+    pairs = ((i, j) for i in group for j in group if i != j)
+    score = sum(self.familiarity_matrix[frozenset(pair)] for pair in pairs)
     return score
   
-  def update_familiarity(self, group: list[str]) -> None:
-    for i in range(len(group)):
-      member_i = self.members.index(group[i])    
-      for j in group[i+1:]:
-        member_j = self.members.index(j)
-        self.familiarity_matrix[member_j][member_i] += 1
-        self.familiarity_matrix[member_i][member_j] += 1
+  def update_familiarity(self, group: set[str]) -> None:
+    pairs = ((i, j) for i in group for j in group if i != j)
+    for pair in pairs:
+      self.familiarity_matrix[frozenset(pair)] += 1
 
-  def calculate_balanced_groups(self, group_count: int, members: list[str] = [], verbose: bool = False) -> list[list[str]]:
+  # Calculate balanced groups by trying to minimize score when choosing which group to add each member to
+  def calculate_balanced_groups(self, group_count: int, members: list[str] = [], verbose: bool = False) -> list[set[str]]:
     random.shuffle(members)
-    groups = [[] for _ in range(group_count)]
+    groups = [set() for _ in range(group_count)]
     scores = {(): 0}
     # Memoized version of evaluate_group for evaluating score when adding one member
-    def evaluate_member(group, member):
-      group_key = tuple(sorted(group))
-      new_key = tuple(sorted(group+[member]))
-      if new_key in scores:
-        return scores[new_key]
-      score = scores[group_key]
+    def evaluate_member(group: set[str], member: str) -> int:
+      new_group: set[str] = group | {member}
+      if frozenset(new_group) in scores:
+        return scores[frozenset(new_group)]
+      score = scores[frozenset(group)] if frozenset(group) in scores else 0
       for i in group:
-        score += self.familiarity_matrix[self.members.index(i)][self.members.index(member)]
-      scores[new_key] = score + 1
-      return score + 1
+        score += self.familiarity_matrix[frozenset((i, member))]
+      scores[frozenset(new_group)] = score + 2
+      return score + 2
 
     # Balance and distribute members
     for member in members:
       min_group_index = min(range(group_count), key=lambda i: evaluate_member(groups[i], member))
-      groups[min_group_index].append(member)
+      groups[min_group_index].add(member)
       if verbose:
         print(groups)
     return groups
 
 
-  def create_balanced_groups(self, group_count: int) -> list[list[str]]:
+  def create_balanced_groups(self, group_count: int) -> list[set[str]]:
     groups = self.calculate_balanced_groups(group_count, self.members.copy())
     return self.create_groups(groups)

--- a/balanced_group_system/group_system.py
+++ b/balanced_group_system/group_system.py
@@ -7,14 +7,14 @@ This module contains a class that represents a group system that creates group_l
 class GroupSystem:  
   def __init__(self, members: list[str] = []):
     self.members: list[str] = members
-    self.group_history: list[list[list[str]]] = []
+    self.group_history: list[list[set[str]]] = []
   
   def __repr__(self) -> str:
     return f"GroupSystem({self.members})"
 
   def print_history(self) -> None:
-    for i, group_list in enumerate(self.group_history):
-      print(i, ':', group_list)
+    for i, group_set in enumerate(self.group_history):
+      print(i, ':', group_set)
   
   def add_member(self, member: str) -> None:
     self.members.append(member)
@@ -23,19 +23,16 @@ class GroupSystem:
     index = self.members.index(member)
     self.members.pop(index)
 
-  def create_groups(self, group_list: list[list[str]]) -> None:
+  def create_groups(self, group_list: list[set[str]]) -> None:
     self.group_history.append(group_list)
 
   # Slower version of create_groups that validates input
-  def create_and_validate_groups(self, group_list: list[list[str]]) -> None:
+  def create_and_validate_groups(self, group_list: list[set[str]]) -> None:
     member_set = set(self.members)
     for group in group_list:
       for member in group:
         try:
           member_set.remove(member)
         except KeyError:
-          if member in self.members:
-            raise ValueError("Duplicate members found in group_list")
-          else:
-            raise KeyError("Element '{}' was not in members".format(member))
+          raise KeyError("Element '{}' was not in members".format(member))
     self.group_history.append(group_list)

--- a/balanced_group_system/parser.py
+++ b/balanced_group_system/parser.py
@@ -4,5 +4,4 @@ def parse_csv(file_name):
   with open(file_name, 'r') as f:
       reader = csv.reader(f)
       members = [row[0] for row in reader]
-  print(members)
   return members

--- a/tests/test_available_group_scheduler.py
+++ b/tests/test_available_group_scheduler.py
@@ -1,0 +1,42 @@
+import pytest
+from balanced_group_system import AvailableGroupScheduler
+
+@pytest.fixture
+def available_group_system():
+  return AvailableGroupScheduler(
+    ['Alice', 'Bob', 'Charlie', 'David', 'Eve'],
+    [[True, True, True, True, False],
+     [True, True, True, False, True],
+     [True, True, False, True, True],
+     [True, False, True, True, True],
+     [False, True, True, True, True]]
+  )
+
+def test_init(available_group_system):
+  assert available_group_system.members == ['Alice', 'Bob', 'Charlie', 'David', 'Eve']
+  assert available_group_system.group_history == []
+  assert available_group_system.familiarity_matrix == {
+    frozenset(('Alice', 'Bob')) : 0,
+    frozenset(('Alice', 'Charlie')) : 0,
+    frozenset(('Alice', 'David')) : 0,
+    frozenset(('Alice', 'Eve')) : 0,
+    frozenset(('Bob', 'Charlie')) : 0,
+    frozenset(('Bob', 'David')) : 0,
+    frozenset(('Bob', 'Eve')) : 0,
+    frozenset(('Charlie', 'David')) : 0,
+    frozenset(('Charlie', 'Eve')) : 0,
+    frozenset(('David', 'Eve')) : 0,
+  }
+
+def test_create_balanced_schedules(available_group_system):
+  assert available_group_system.create_balanced_schedules(4) == [
+    {'Alice', 'Bob', 'Charlie', 'David'},
+    {'Alice', 'Bob', 'Charlie', 'Eve'},
+    {'Alice', 'Bob', 'David', 'Eve'},
+    {'Alice', 'Charlie', 'David', 'Eve'},
+    {'Bob', 'Charlie', 'David', 'Eve'}
+  ]
+
+def test_get_balanced_group(available_group_system):
+  assert available_group_system.get_balanced_group({'Alice', 'Bob', 'Charlie', 'David'}, set(), 4) == {'Alice', 'Bob', 'Charlie', 'David'}
+  assert available_group_system.get_balanced_group({'Alice', 'Bob', 'Charlie'}, {'David'}, 4) == {'Alice', 'Bob', 'Charlie', 'David'}

--- a/tests/test_balanced_group_system.py
+++ b/tests/test_balanced_group_system.py
@@ -7,32 +7,67 @@ def balanced_group_system():
 
 def test_init(balanced_group_system):
   assert balanced_group_system.members == ['Alice', 'Bob', 'Charlie', 'David', 'Eve']
-  assert balanced_group_system.familiarity_matrix == [[0, 0, 0, 0, 0] for _ in range(5)]
+  assert balanced_group_system.familiarity_matrix == {
+    frozenset(('Alice', 'Bob')) : 0,
+    frozenset(('Alice', 'Charlie')) : 0,
+    frozenset(('Alice', 'David')) : 0,
+    frozenset(('Alice', 'Eve')) : 0,
+    frozenset(('Bob', 'Charlie')) : 0,
+    frozenset(('Bob', 'David')) : 0,
+    frozenset(('Bob', 'Eve')) : 0,
+    frozenset(('Charlie', 'David')) : 0,
+    frozenset(('Charlie', 'Eve')) : 0,
+    frozenset(('David', 'Eve')) : 0,
+  }
 
 def test_add_member(balanced_group_system):
   balanced_group_system.add_member('Frank')
   assert balanced_group_system.members == ['Alice', 'Bob', 'Charlie', 'David', 'Eve', 'Frank']
-  assert balanced_group_system.familiarity_matrix == [[0, 0, 0, 0, 0, 0] for _ in range(6)]
+  assert balanced_group_system.familiarity_matrix == {
+    frozenset(('Alice', 'Bob')) : 0,
+    frozenset(('Alice', 'Charlie')) : 0,
+    frozenset(('Alice', 'David')) : 0,
+    frozenset(('Alice', 'Eve')) : 0,
+    frozenset(('Bob', 'Charlie')) : 0,
+    frozenset(('Bob', 'David')) : 0,
+    frozenset(('Bob', 'Eve')) : 0,
+    frozenset(('Charlie', 'David')) : 0,
+    frozenset(('Charlie', 'Eve')) : 0,
+    frozenset(('David', 'Eve')) : 0,
+    frozenset(('Frank', 'Alice')) : 0,
+    frozenset(('Frank', 'Bob')) : 0,
+    frozenset(('Frank', 'Charlie')) : 0,
+    frozenset(('Frank', 'David')) : 0,
+    frozenset(('Frank', 'Eve')) : 0,
+  }
 
 def test_remove_member(balanced_group_system):
   balanced_group_system.remove_member('Bob')
   assert balanced_group_system.members == ['Alice', 'Charlie', 'David', 'Eve']
-  assert balanced_group_system.familiarity_matrix == [[0, 0, 0, 0] for _ in range(4)]
+  assert balanced_group_system.familiarity_matrix == {
+    frozenset(('Alice', 'Charlie')) : 0,
+    frozenset(('Alice', 'David')) : 0,
+    frozenset(('Alice', 'Eve')) : 0,
+    frozenset(('Charlie', 'David')) : 0,
+    frozenset(('Charlie', 'Eve')) : 0,
+    frozenset(('David', 'Eve')) : 0,
+  }
 
 def test_create_groups(balanced_group_system):
   groups = [['Alice', 'Bob'], ['Charlie', 'David', 'Eve']]
   balanced_group_system.create_groups(groups)
-  assert balanced_group_system.familiarity_matrix[0][1] == 1
-  assert balanced_group_system.familiarity_matrix[2][3] == 1
-  assert balanced_group_system.familiarity_matrix[2][4] == 1
-  assert balanced_group_system.familiarity_matrix[3][4] == 1
+  assert balanced_group_system.group_history[0] == groups
+  assert balanced_group_system.familiarity_matrix[frozenset(('Alice', 'Bob'))] == 2
+  assert balanced_group_system.familiarity_matrix[frozenset(('Charlie', 'David'))] == 2
+  assert balanced_group_system.familiarity_matrix[frozenset(('Charlie', 'Eve'))] == 2
+  assert balanced_group_system.familiarity_matrix[frozenset(('David', 'Eve'))] == 2
 
 def test_update_familiarity(balanced_group_system):
   group = ['Alice', 'Bob', 'Charlie']
   balanced_group_system.update_familiarity(group)
-  assert balanced_group_system.familiarity_matrix[0][1] == 1
-  assert balanced_group_system.familiarity_matrix[0][2] == 1
-  assert balanced_group_system.familiarity_matrix[1][2] == 1
+  assert balanced_group_system.familiarity_matrix[frozenset(('Alice', 'Bob'))] == 2
+  assert balanced_group_system.familiarity_matrix[frozenset(('Alice', 'Charlie'))] == 2
+  assert balanced_group_system.familiarity_matrix[frozenset(('Bob', 'Charlie'))] == 2
 
 def test_calculate_balanced_groups(balanced_group_system):
   groups = balanced_group_system.calculate_balanced_groups(2, balanced_group_system.members)

--- a/tests/test_group_system.py
+++ b/tests/test_group_system.py
@@ -28,9 +28,4 @@ def test_create_validate_groups(group_system):
   # Test case: Member not in groupSystem.members
   with pytest.raises(KeyError) as exc_info:
     group_system.create_and_validate_groups([['Alice', 'Bob'], ['Charlie', 'David', 'Frank']])
-    assert str(exc_info.value) == "Element 'Frank' was not in members list"
-  
-  # Test case: Duplicate member within a group
-  with pytest.raises(ValueError) as exc_info:
-    group_system.create_and_validate_groups([['Alice', 'Bob'], ['Charlie', 'Charlie']])
-    assert str(exc_info.value) == "Duplicate members found in group_list"
+    assert str(exc_info.value) == "Key Error: Element 'Frank' was not in members list"


### PR DESCRIPTION
- Implementation of balanced_group_system now treats groups as sets rather than lists/indexes
  - by default groups can no longer have duplicates (so no validations)
- Newly implemented [available_group_scheduler](https://github.com/joshSi/balanced_group_system/blob/a198784b63f8350c5746cf515e34a7c6f38b2f86/balanced_group_system/available_group_scheduler.py) schedules groups to equalize the amount of times each member participates and is grouped with others, while also taking in each member's availability